### PR TITLE
Minor fixes

### DIFF
--- a/lastfm_queue.py
+++ b/lastfm_queue.py
@@ -79,7 +79,7 @@ class LastFmQueuePlugin (GObject.Object, Peas.Activatable):
 		self.db = shell.get_property('db')
 		sp = shell.props.shell_player
 		self.pec_id = sp.connect ('playing-song-changed', self.playing_entry_changed)
-		self.pc_id = sp.connect ('playing-changed', self.playing_changed)
+		#self.pc_id = sp.connect ('playing-changed', self.playing_changed)
 		self.sc_id = sp.connect ('playing-source-changed', self.source_changed)
 		self.past_entries = []
 		self.current_entry = None
@@ -99,7 +99,7 @@ class LastFmQueuePlugin (GObject.Object, Peas.Activatable):
 		sp = self.shell.props.shell_player
 		self.shell = None
 		sp.disconnect (self.pec_id)
-		sp.disconnect (self.pc_id)
+		#sp.disconnect (self.pc_id)
 		sp.disconnect (self.sc_id)
 
 	def toggle_dynamic(self, action, shell):


### PR DESCRIPTION
There might be a better way, but [0d8ac92](https://github.com/eevans/lastfm_queue/commit/0d8ac928e07b790e48336c7eedb02786bfc5db8e) fixes a bug whereby the queue grows by two tracks for every one played (which also results in  two lastfm API calls per track).

[32ea615](https://github.com/eevans/lastfm_queue/commit/32ea615d05b4207d48f147519f7371116ae61c24) not only results in fewer lastfm API calls, but provides better results for me.
